### PR TITLE
Change the alpine repository URL from testing to community

### DIFF
--- a/node_exporter/Dockerfile.template
+++ b/node_exporter/Dockerfile.template
@@ -1,7 +1,7 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 WORKDIR /app
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     apk add --no-cache prometheus-node-exporter
 
 # Expose the port Prometheus uses


### PR DESCRIPTION
Now the installation of node_exporter fails, because the testing repository for alpine is a 404. 
So let's switch to the community repository.